### PR TITLE
Feature ETO-3518: enhance access control and user roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,187 +1,272 @@
-# Etendo Agents – n8n Chat Interface
+# Etendo Chat Interface
 
-An application that authenticates users with Supabase, proxies chat traffic to n8n workflows, and keeps long-lived conversation history in MongoDB. It includes an admin console for managing chat agents, dynamic
-access control per agent, and a rich chat surface supporting files, audio notes, link previews, and feedback collection.
+Next.js application for Etendo support and customer chat. It authenticates users with Supabase, stores conversation history in MongoDB, proxies messages to n8n workflows, and can route selected agents through Chatwoot.
 
-## Feature Highlights
-- Email/password and Google OAuth sign-in with Supabase, including Jira-based partner verification and session refresh in middleware.
-- Role-aware navigation (admin, partner, non_client/guest) with protected routes, agent-level access tiers, and an admin-only management panel.
-- Agent metadata (name, description) and quick-start prompts are stored with locale-aware translations so the UI tracks the active language automatically.
-- Responsive chat workspace with conversation history, streaming responses from n8n, attachments, audio recording, video-analysis flagging, and feedback prompts.
-- Agent catalog sourced from Supabase with inline create/update/delete, icon/color configuration, and webhook endpoints per agent.
-- MongoDB-backed conversation archive with rename/delete/search/pagination and per-user isolation.
-- Ancillary APIs for link previews and webhook proxying that forward uploaded files/audio to n8n or Chatwoot, preserving metadata such as the **video analysis** flag and rendering inbound Chatwoot attachments (images, audio, files) in the UI.
+## What this project does
 
-## Architecture Overview
-- **Next.js App Router** (`app/`) renders public auth flows and authenticated layouts; middleware guards the home dashboard.
-- **Supabase** handles authentication, session cookies, and tables (`profiles`, `agents`, `agent_translations`, `agent_prompts`, `feedback`) accessed through `@/lib/supabase`.
-- **MongoDB** stores conversations in the `conversations` collection (documents contain `messages`, `sessionId`, `agentId`, timestamps, etc.).
-- **n8n** receives chat payloads via `/api/webhook`, streams newline-delimited JSON chunks, and returns agent replies.
-- **UI Layer** is built with Tailwind CSS 4, shadcn/ui components, and custom gradients in `globals.css`.
+- Provides email/password and Google OAuth authentication.
+- Classifies authenticated users with Jira-based memberships.
+- Enforces per-agent access control for `public`, `non_client`, `partner`, `customer`, and `admin` experiences.
+- Renders a chat UI with attachments, audio messages, link previews, conversation history, and feedback.
+- Sends messages either to n8n workflows or to Chatwoot inboxes, depending on agent configuration.
 
+## Stack
 
-app/
-├─ auth/                Public auth flows (register with Jira check, login redirect by role)
-├─ (authenticated)/     Logged-in shell (global header, dashboard, chat, admin)
-│  ├─ page.tsx          Home listing of partner/admin agents
-│  ├─ chat/[agent]/     Chat workspace with conversation history & ACL check
-│  └─ admin/            Admin panel gating and agent management
-├─ api/                 Edge/server routes (webhook proxy, link preview)
-├─ layout.tsx           Root metadata and font setup
-└─ middleware.ts        Session refresh + lightweight route protection
-components/
-├─ chat-interface.tsx   Client chat surface (stream handling, attachments, audio, video flag)
-├─ chat-layout.tsx      Layout that injects sidebar history for signed users
-├─ conversation-history-content(-logic).tsx
-│                       Search/pagination/rename/delete tied to server actions
-├─ global-header.tsx    Role-aware nav + mobile sheet, hides login for guest agents
-└─ ui/                  shadcn component library
-lib/
-├─ actions/             Server actions for conversations, titles, feedback
-├─ mongodb.ts           Cached MongoDB connector
-└─ supabase/            Browser and server Supabase clients
+- `Next.js 14` with App Router
+- `Supabase` for auth and application tables
+- `MongoDB` for conversation persistence
+- `n8n` for automation and AI workflows
+- `Chatwoot` for inbox-based conversations
+- `next-intl` for `en` and `es`
+- `Vitest` for tests
 
+## High-level architecture
 
-## Roles & Access Control
+- `app/` contains the localized UI, auth flows, authenticated pages, and API routes.
+- `components/` contains the chat UI, admin UI, and shared interface components.
+- `lib/` contains access control, auth helpers, MongoDB access, Supabase helpers, and server actions.
+- `workflow/` contains exported n8n workflows used by the app.
+- `supabase/migrations/` contains SQL migrations for the application schema.
 
-| Role        | How assigned                                                               | Home (`/`) | Chat (`/chat/[agent]`)                                  | Admin (`/admin`) |
-|-------------|-----------------------------------------------------------------------------|------------|---------------------------------------------------------|------------------|
-| `admin`     | Manually set in `profiles` or promoted in Supabase                         | ✅         | ✅ all agents                                           | ✅               |
-| `partner`   | Jira webhook returns `isJiraUser: true` during sign up / OAuth              | ✅         | ✅ agents marked `partner`                              | ⛔               |
-| `non_client`| Default for regular sign ups (no Jira match)                                | ✅         | ✅ agents marked `non_client`                           | ⛔               |
-| Guest       | Unauthenticated visitor                                                     | ⛔ (redirected to login) | ✅ only agents marked `public` (guests only)             | ⛔               |
+## Main flows
 
-Additional notes:
-- `/` is guarded by middleware and returns only partner/admin agents (public agents are intentionally hidden from authenticated users).
-- `/chat/[agent]` revalidates the agent record and enforces the agent-level `access_level` (`public`, `non_client`, `partner`, `admin`) before rendering.
-- `/admin` redirects non-admins back to `/`.
+### Authentication
 
-## Data Model Expectations
+- Email/password login is handled with Supabase client auth.
+- Google OAuth is completed in `app/[locale]/auth/callback/route.ts`.
+- After sign up or OAuth login, the app calls `JIRA_WEBHOOK_URL` to resolve Jira memberships.
 
-### Supabase Tables
-- `profiles`: `{ id (UUID, matches auth.user.id), role text }`
-- `agents`: `{ id uuid, name, description, webhookurl, path, color, icon, access_level }`<br/>`name`/`description` remain for backwards compatibility and as fallback values.
-- `agent_translations`: `{ id, agent_id → agents.id, locale, name, description, created_at, updated_at }`
-- `agent_prompts`: `{ id, agent_id → agents.id, locale, content, sort_order, created_at }`
-- `feedback`: `{ id, message_id, conversation_id, agent_id, rating, feedback_text, user_id }`
+### Jira membership resolution
 
-> Ensure row-level security policies allow the application to read/write rows owned by the current user (and full access for admin users where required).
+The Jira webhook is expected to return:
 
-### MongoDB (`conversations` collection)
-Each document resembles:
 ```json
 {
-  "_id": ObjectId,
-  "sessionId": "uuid-or-random",
-  "agentId": "supabase_agent_id",
-  "email": "user@example.com",
-  "conversationTitle": "First prompt…",
-  "messages": [{ "type": "human"|"ai", "data": { "content": "..." } }],
-  "createdAt": ISODate,
-  "updatedAt": ISODate
+  "isJiraUser": true,
+  "isESD": true,
+  "isCSP": false
 }
 ```
 
-Queries always include email to enforce per-user isolation.
+The app maps that response to profile memberships:
 
-## Integrating n8n
+- `isESD -> is_partner`
+- `isCSP -> is_customer`
+- `role` is kept for backward compatibility and admin handling
 
-- Each agent’s webhookurl should point to the base n8n endpoint that will receive chat payloads.
-- The proxy (/api/webhook) forwards FormData fields:
+This allows one user to belong to both Service Desks at the same time.
 
-  | Field         | Description                                                |
-  |---------------|------------------------------------------------------------|
-  | message     | Trimmed user text or placeholder ([Audio message], etc.) |
-  | agentId     | Supabase agent UUID                                        |
-  | sessionId   | Stable ID (userId + timestamp or stored conversation)      |
-  | conversationId | Current Mongo _id, when available                      |
-  | userEmail   | Authenticated user email (optional for guests)             |
-  | videoAnalysis | "true" when a video upload should trigger extra logic  |
-  | file_*      | Any uploaded files                                         |
-  | audio       | Recorded audio clip (audio/webm)                         |
-- n8n should respond with a streaming body where each line is JSON; chat-interface looks for objects like:
+### Chat delivery
 
-  {"type":"item","content":"partial response text"}
+- `app/api/webhook/route.ts` is the main entry point used by the chat UI.
+- Standard agents forward requests to the configured n8n webhook.
+- Agents with `chatwoot_inbox_identifier` are routed through Chatwoot instead.
+- Chatwoot live updates are streamed from `app/api/chatwoot/stream/route.ts` with Server-Sent Events.
 
-  and may emit an early line containing { "conversationId": "<mongo-id>" } to update the URL.
+## Access model
 
-## Environment Configuration
+### Profile access state
 
-Create .env.local with:
+`profiles` now supports both legacy role information and explicit Jira memberships:
 
-NEXT_PUBLIC_SUPABASE_URL=...
-NEXT_PUBLIC_SUPABASE_ANON_KEY=...
-MONGODB_URI=mongodb+srv://...
-MONGODB_DB_NAME=chat_history         # optional override
-JIRA_WEBHOOK_URL=https://...         # POST endpoint returning { isJiraUser: boolean }
-CHATWOOT_BASE_URL=https://chatwoot.example.com
-CHATWOOT_ACCOUNT_ID=1
-CHATWOOT_API_TOKEN=xxxxxx              # public API inbox token for uploads
-CHATWOOT_WEBHOOK_TOKEN=secret-value    # shared secret that Chatwoot will use when calling /api/chatwoot/webhook
-NEXT_PUBLIC_GA_ID=G-XXXXXXXXXX       # optional GA4 measurement ID
+- `role`
+- `is_partner`
+- `is_customer`
 
-If you run locally, also provide NEXT_PUBLIC_SITE_URL to n8n if needed (not referenced in code).
+The effective access state is built in `lib/auth/access-state.ts`.
 
-## Getting Started
+### Agent access levels
 
-1. Install dependencies
+Each record in `agents.access_level` must be one of:
 
-    npm install            # or pnpm install / yarn
-2. Configure environment
-    - Populate .env.local with the variables above.
-    - Seed Supabase with at least one admin profile and a starter agent.
-3. Run development server
+- `public`: guest-only access
+- `non_client`: authenticated users without Jira memberships
+- `partner`: users with `is_partner = true`
+- `customer`: users with `is_customer = true`
+- `admin`: admins only
 
-    npm run dev
-    Visit http://localhost:3000.
-4. Production build
+Access rules are enforced in `lib/agents/access.ts`.
 
-    npm run build
-    npm start
+### Important behavior
 
-## Admin Workflow
+- `admin` bypasses all agent restrictions.
+- `partner + customer` users can access both partner and customer agents.
+- `non_client` means authenticated but not matched to ESD or CSP.
+- `public` agents are for unauthenticated visitors only.
 
-- Navigate to /admin as an admin user.
-- Use “New Agent” to create entries; each agent can now define name/description per locale in the translations tab (default locale is required) alongside webhook URL (base), path (leading /), icon emoji, color class, access level, and ordered prompts for every locale.
-- Existing agents can be edited or deleted; operations upsert both the base agent row and the locale translations with toast feedback on success/error.
+## Data model
 
-## Chat Experience
+### Supabase tables
 
-- Sidebar lists 10 most recent conversations (with infinite scroll, search, rename, delete) via server actions (fetchConversations, updateConversationTitle, deleteConversation).
-- Chat composer supports:
-    - Enter to send, Shift/Ctrl+Enter for new line.
-    - File uploads (up to 10 MB each), audio recording (webm), and optional video analysis flag.
-    - Markdown rendering, link previews via /api/link-preview, YouTube embeds, attachment download buttons, and rating/feedback submission.
-    - Session IDs persist per conversation; guests get a generated UUID, authenticated users load existing history.
-- New conversations render any locale-specific prompts configured for the agent (falling back to the default locale when needed) as introductory agent bubbles before user input.
+Minimum expected tables:
 
-## Chatwoot Integration
+- `profiles`
+  - `id uuid`
+  - `role text`
+  - `is_partner boolean`
+  - `is_customer boolean`
+- `agents`
+  - `id uuid`
+  - `name text`
+  - `description text`
+  - `webhookurl text`
+  - `path text`
+  - `color text`
+  - `icon text`
+  - `access_level text`
+  - `requires_email boolean`
+  - `chatwoot_inbox_identifier text`
+- `agent_translations`
+  - localized `name` and `description`
+- `agent_prompts`
+  - localized initial prompts per agent
+- `feedback`
+  - message feedback submitted from the chat UI
 
-When an agent has `chatwoot_inbox_identifier` configured, outbound messages are proxied to Chatwoot instead of n8n:
+### MongoDB
 
-- `/api/webhook` upserts the Chatwoot contact and propagates uploaded files/audio as real attachments. The optional `videoAnalysis=true` flag is passed along in `content_attributes`/`additional_attributes`, so the inbox can act on that metadata.
-- Incoming events from Chatwoot (`/api/chatwoot/webhook`) deliver attachments and the same attributes back to the app; the chat UI renders images/audio received from human agents.
-- Environment variables required on the app side: `CHATWOOT_BASE_URL`, `CHATWOOT_ACCOUNT_ID`, `CHATWOOT_API_TOKEN`, `CHATWOOT_WEBHOOK_TOKEN`.
-- In Chatwoot, configure an API inbox and set its public identifier on the agent. For webhooks, create a webhook pointing to `/api/chatwoot/webhook` and reuse the same secret value stored in `CHATWOOT_WEBHOOK_TOKEN` so signatures validate correctly.
+The app stores conversation history in the `conversations` collection.
 
-## Authentication Flow
+Typical fields include:
 
-- Register: uses signUpWithJiraCheck server action; Jira webhook determines initial role (partner vs non_client).
-- Login: fetches profiles.role to route admins to /admin, others to /.
-- Google OAuth: handled under /auth/callback, including Jira role detection and skip if existing admin.
-- Sign-out: /auth/signout clears Supabase session tokens.
+- `sessionId`
+- `agentId`
+- `email`
+- `conversationTitle`
+- `messages`
+- `createdAt`
+- `updatedAt`
+- optional Chatwoot metadata such as `chatwootConversationId`
 
-## Deployment Notes
+## Included n8n workflows
 
-- Audio recording requires HTTPS in browsers.
-- Supabase server client relies on cookies; middleware refreshes sessions so pages stay up to date.
-- MongoDB connection is cached; adjust maxPoolSize in lib/mongodb.ts for high throughput.
-- With `NEXT_PUBLIC_GA_ID` set, GA4 receives `agent_view` and `agent_message_sent` events that include agent identifiers, access level, and attachment metadata for reporting.
-- Consider enabling Vercel edge runtime for streaming routes if deploying there (current webhook route runs on Node runtime).
+- `workflow/check-jira-user-webhook.json`
+  - receives an email
+  - checks Jira user existence and Service Desk memberships
+  - returns `isJiraUser`, `isESD`, `isCSP`
+- `workflow/support-agent.json`
+  - support-oriented workflow used by the app for technical assistance
 
-## Troubleshooting
+## API routes
 
-- Agents not visible: ensure access_level matches the user role; home page excludes public agents by design.
-- “Access Denied” in chat: confirm agent path (prefixed with /) and role assignment in profiles.
-- Link preview errors: only HTML content is parsed; non-HTML responses return a fallback. Network restrictions may block outbound fetches locally.
-- Streaming stalls: verify n8n returns newline-delimited JSON and does not buffer entire response.
+- `app/api/webhook/route.ts`
+  - main chat entry point
+  - forwards requests to n8n or Chatwoot
+- `app/api/chatwoot/stream/route.ts`
+  - SSE polling bridge for Chatwoot conversations
+- `app/api/chatwoot/webhook/route.ts`
+  - validates Chatwoot webhook signatures
+- `app/api/chatwoot/messages/route.ts`
+  - Chatwoot message retrieval endpoint used by the UI
+- `app/api/link-preview/route.ts`
+  - safe HTML metadata extraction for link previews
+- `app/api/email/validate/route.ts`
+  - proxies email validation to an external provider
+
+## Environment variables
+
+Create `.env.local` with the values required by your environment.
+
+### Required for the app
+
+```bash
+NEXT_PUBLIC_SUPABASE_URL=
+NEXT_PUBLIC_SUPABASE_ANON_KEY=
+MONGODB_URI=
+JIRA_WEBHOOK_URL=
+```
+
+### Optional but commonly needed
+
+```bash
+MONGODB_DB_NAME=
+CHATWOOT_BASE_URL=
+CHATWOOT_ACCOUNT_ID=
+CHATWOOT_API_TOKEN=
+CHATWOOT_WEBHOOK_TOKEN=
+CHATWOOT_MESSAGE_POLL_INTERVAL_MS=
+CHATWOOT_LABEL_POLL_INTERVAL_MS=
+NEXT_PUBLIC_GA_ID=
+NEXT_PUBLIC_SITE_URL=
+```
+
+## Local setup
+
+1. Install dependencies.
+
+```bash
+npm install
+```
+
+2. Configure `.env.local`.
+
+3. Prepare Supabase:
+   - create the expected tables
+   - ensure at least one `admin` profile exists
+   - apply migrations from `supabase/migrations/`
+
+4. Import and configure the n8n workflows you need.
+
+5. Run the app.
+
+```bash
+npm run dev
+```
+
+6. Open `http://localhost:3000`.
+
+## Database migration notes
+
+The repository includes `supabase/migrations/20260306120000_add_profile_memberships.sql`.
+
+That migration is additive:
+
+- adds `is_partner`
+- adds `is_customer`
+- backfills `is_partner` for existing `partner` users
+
+It does not rename or drop `profiles.role`.
+
+## Admin usage
+
+Admins can manage agents from `/[locale]/admin`.
+
+For each agent, the admin UI supports:
+
+- base metadata
+- translated name and description
+- localized initial prompts
+- access level selection
+- optional Chatwoot inbox identifier
+- `requires_email` gating before chat starts
+
+## Development commands
+
+```bash
+npm run dev
+npm run build
+npm start
+npm test
+npm run db:create-indexes
+```
+
+## Testing
+
+- Unit and integration tests run with `Vitest`.
+- The most relevant access and auth flows are covered under `tests/`.
+- If you run full TypeScript checks, note that the repository may contain unrelated pre-existing type issues outside the core chat/auth flow.
+
+## Operational notes
+
+- Middleware only handles locale routing; auth and ACL checks are done in the pages and server logic.
+- Public agents are intentionally hidden from authenticated users.
+- Chatwoot support requires valid Chatwoot credentials and inbox identifiers stored on agents.
+- Link previews are restricted to safe external HTTP/HTTPS targets and reject localhost/private addresses.
+
+## Recommended deployment checklist
+
+- Supabase auth configured for your site URL and OAuth callbacks
+- MongoDB reachable from the deployment environment
+- `JIRA_WEBHOOK_URL` pointing to the active n8n Jira membership workflow
+- Chatwoot variables configured if any agent uses Chatwoot
+- n8n workflows published and reachable from the app

--- a/app/[locale]/(authenticated)/admin/AdminPanelClient.tsx
+++ b/app/[locale]/(authenticated)/admin/AdminPanelClient.tsx
@@ -15,7 +15,7 @@ import { supabase } from "@/lib/supabaseClient";
 import { useTranslations } from "next-intl";
 import type { Locale } from "@/i18n/config";
 
-type AccessLevel = "public" | "non_client" | "partner" | "admin";
+type AccessLevel = "public" | "non_client" | "partner" | "customer" | "admin";
 
 interface AgentTranslation {
   name: string;
@@ -47,18 +47,18 @@ interface AdminAgent {
 
 interface AdminPanelClientProps {
   initialAgents: AdminAgent[];
-  locales: Locale[];
+  locales: readonly Locale[];
   defaultLocale: Locale;
   displayLocale: Locale;
 }
 
-const createEmptyTranslations = (localeList: Locale[]): AgentTranslations =>
+const createEmptyTranslations = (localeList: readonly Locale[]): AgentTranslations =>
   localeList.reduce((acc, locale) => {
     acc[locale] = { name: "", description: "" };
     return acc;
   }, {} as AgentTranslations);
 
-const cloneTranslations = (translations: AgentTranslations, localeList: Locale[]): AgentTranslations =>
+const cloneTranslations = (translations: AgentTranslations, localeList: readonly Locale[]): AgentTranslations =>
   localeList.reduce((acc, locale) => {
     const source = translations?.[locale];
     acc[locale] = {
@@ -68,13 +68,13 @@ const cloneTranslations = (translations: AgentTranslations, localeList: Locale[]
     return acc;
   }, {} as AgentTranslations);
 
-const createEmptyPrompts = (localeList: Locale[]): AgentPrompts =>
+const createEmptyPrompts = (localeList: readonly Locale[]): AgentPrompts =>
   localeList.reduce((acc, locale) => {
     acc[locale] = [];
     return acc;
   }, {} as AgentPrompts);
 
-const clonePrompts = (prompts: AgentPrompts, localeList: Locale[]): AgentPrompts =>
+const clonePrompts = (prompts: AgentPrompts, localeList: readonly Locale[]): AgentPrompts =>
   localeList.reduce((acc, locale) => {
     const sourceList = prompts?.[locale] ?? [];
     acc[locale] = sourceList.map((prompt) => ({ ...prompt }));
@@ -368,7 +368,7 @@ export function AdminPanelClient({ initialAgents, locales, defaultLocale, displa
 
 interface AgentEditorProps {
   agent: AdminAgent;
-  locales: Locale[];
+  locales: readonly Locale[];
   defaultLocale: Locale;
   onSave: (agent: AdminAgent) => void;
   onCancel: () => void;
@@ -648,6 +648,7 @@ function AgentEditor({ agent, locales, defaultLocale, onSave, onCancel }: AgentE
             <SelectItem value="public">{t('accessLevel.options.public')}</SelectItem>
             <SelectItem value="non_client">{t('accessLevel.options.non_client')}</SelectItem>
             <SelectItem value="partner">{t('accessLevel.options.partner')}</SelectItem>
+            <SelectItem value="customer">{t('accessLevel.options.customer')}</SelectItem>
             <SelectItem value="admin">{t('accessLevel.options.admin')}</SelectItem>
           </SelectContent>
         </Select>

--- a/app/[locale]/(authenticated)/admin/page.tsx
+++ b/app/[locale]/(authenticated)/admin/page.tsx
@@ -5,20 +5,21 @@ import { redirect } from 'next/navigation';
 
 import { AdminPanelClient } from './AdminPanelClient';
 import { Agent } from '@/components/chat-interface';
+import { buildProfileAccessState } from '@/lib/auth/access-state';
 import { getTranslations } from 'next-intl/server';
 import { locales, defaultLocale, type Locale } from '@/i18n/config';
 
-async function getUserRole(supabaseClient: any, userId: string) {
+async function getUserAccessState(supabaseClient: any, userId: string) {
     const { data: profile, error } = await supabaseClient
         .from('profiles')
-        .select('role')
+        .select('role, is_partner, is_customer')
         .eq('id', userId)
         .single();
 
     if (error || !profile) {
         return null;
     }
-    return profile.role as 'admin' | 'partner';
+    return buildProfileAccessState(profile);
 }
 
 export default async function AdminPage({ params }: { params: { locale: Locale } }) {
@@ -44,9 +45,9 @@ export default async function AdminPage({ params }: { params: { locale: Locale }
         redirect('/auth/login');
     }
 
-    const userRole = await getUserRole(supabase, user.id);
+    const accessState = await getUserAccessState(supabase, user.id);
 
-    if (userRole !== 'admin') {
+    if (accessState?.isAdmin !== true) {
         redirect('/');
     }
 

--- a/app/[locale]/(authenticated)/chat/[agentPath]/[[...conversationId]]/page.tsx
+++ b/app/[locale]/(authenticated)/chat/[agentPath]/[[...conversationId]]/page.tsx
@@ -4,6 +4,7 @@ import { createClient } from '@/lib/supabase/server';
 import { getConversationHistory, getConversationMetadata, getMessagesForConversation } from '@/lib/actions/chat';
 import { fetchChatwootConversationMessages } from '@/lib/chatwoot/api';
 import { canUserAccessAgent } from '@/lib/agents/access';
+import { buildProfileAccessState, getUserAccessLabel } from '@/lib/auth/access-state';
 import ChatLayout from '@/components/chat-layout';
 import { Agent } from '@/components/chat-interface';
 import { ChatContextProvider } from '@/lib/chat-context';
@@ -60,17 +61,17 @@ export async function generateMetadata({ params }: { params: { locale: string; a
     }
 }
 
-async function getUserRole(supabaseClient: any, userId: string) {
+async function getUserAccessState(supabaseClient: any, userId: string) {
     const { data: profile, error } = await supabaseClient
         .from('profiles')
-        .select('role')
+        .select('role, is_partner, is_customer')
         .eq('id', userId)
         .single();
 
     if (error || !profile) {
         return null;
     }
-    return profile.role as 'admin' | 'partner' | 'non_client';
+    return buildProfileAccessState(profile);
 }
 
 export default async function ChatPage({ params }: { params: { locale: string; agentPath: string; conversationId?: string[] } }) {
@@ -94,10 +95,10 @@ export default async function ChatPage({ params }: { params: { locale: string; a
         return <div className="p-4">{t('errors.agentNotFound')}</div>;
     }
 
-    const userRole = user ? await getUserRole(supabaseClient, user.id) : null;
+    const accessState = user ? await getUserAccessState(supabaseClient, user.id) : null;
 
     const isAuthenticated = Boolean(user);
-    if (!canUserAccessAgent({ accessLevel: agent.access_level, userRole, isAuthenticated })) {
+    if (!canUserAccessAgent({ accessLevel: agent.access_level, accessState, isAuthenticated })) {
         if (!isAuthenticated) {
             redirect(`/${params.locale}/auth/login`);
         }
@@ -240,7 +241,7 @@ export default async function ChatPage({ params }: { params: { locale: string; a
                 initialChatwootConversationId={agent.chatwoot_inbox_identifier ? (initialChatwootConversationId ?? null) : null}
                 initialConversations={initialConversations}
                 agentPath={params.agentPath}
-                userRole={userRole}
+                userRole={getUserAccessLabel(accessState)}
                 initialPrompts={prompts.map((prompt, index) => ({
                     id: prompt.id ?? `prompt-${index}`,
                     content: prompt.content,

--- a/app/[locale]/(authenticated)/layout.tsx
+++ b/app/[locale]/(authenticated)/layout.tsx
@@ -1,18 +1,19 @@
 import '../../globals.css'
 import { createClient } from '@/lib/supabase/server';
+import { buildProfileAccessState, getUserAccessLabel } from '@/lib/auth/access-state';
 import AuthenticatedLayoutClient from './authenticated-layout-client';
 
-async function getUserRole(supabaseClient: any, userId: string) {
+async function getUserAccessState(supabaseClient: any, userId: string) {
     const { data: profile, error } = await supabaseClient
         .from('profiles')
-        .select('role')
+        .select('role, is_partner, is_customer')
         .eq('id', userId)
         .single();
 
     if (error || !profile) {
         return null;
     }
-    return profile.role as 'admin' | 'partner';
+    return buildProfileAccessState(profile);
 }
 
 export default async function AuthenticatedLayout({
@@ -22,10 +23,10 @@ export default async function AuthenticatedLayout({
 }>) {
     const supabaseClient = createClient();
     const { data: { user } } = await supabaseClient.auth.getUser();
-    const userRole = user ? await getUserRole(supabaseClient, user.id) : null;
+    const accessState = user ? await getUserAccessState(supabaseClient, user.id) : null;
 
     return (
-        <AuthenticatedLayoutClient user={user} userRole={userRole}>
+        <AuthenticatedLayoutClient user={user} userRole={getUserAccessLabel(accessState)}>
             {children}
         </AuthenticatedLayoutClient>
     )

--- a/app/[locale]/(authenticated)/page.tsx
+++ b/app/[locale]/(authenticated)/page.tsx
@@ -4,21 +4,22 @@ import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 import { Agent } from '@/components/chat-interface';
 import { shouldListAgentOnHome } from '@/lib/agents/access';
+import { buildProfileAccessState } from '@/lib/auth/access-state';
 import { getTranslator } from '@/i18n/translator';
 import type { Locale } from '@/i18n/config';
 import HomeAgentCard from '@/components/home-agent-card';
 
-async function getUserRole(supabaseClient: any, userId: string) {
+async function getUserAccessState(supabaseClient: any, userId: string) {
     const { data: profile, error } = await supabaseClient
         .from('profiles')
-        .select('role')
+        .select('role, is_partner, is_customer')
         .eq('id', userId)
         .single();
 
     if (error || !profile) {
         return null;
     }
-    return profile.role as 'admin' | 'partner';
+    return buildProfileAccessState(profile);
 }
 
 export default async function Home({ params }: { params: { locale: Locale } }) {
@@ -44,7 +45,7 @@ export default async function Home({ params }: { params: { locale: Locale } }) {
     if (!user) {
         redirect(`${localePrefix}/auth/login`);
     }
-    const userRole = await getUserRole(supabaseClient, user.id);
+    const accessState = await getUserAccessState(supabaseClient, user.id);
 
     const { data: agents, error: agentsError } = await supabaseClient.from('agents').select('*');
 
@@ -78,7 +79,7 @@ export default async function Home({ params }: { params: { locale: Locale } }) {
         };
     });
 
-    const filteredAgents = localizedAgents.filter(agent => shouldListAgentOnHome(agent.access_level, userRole));
+    const filteredAgents = localizedAgents.filter(agent => shouldListAgentOnHome(agent.access_level, accessState));
 
     return (
         <div className='mx-auto w-full max-w-7xl px-6 py-8 md:px-10'>

--- a/app/[locale]/auth/callback/route.ts
+++ b/app/[locale]/auth/callback/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
+import { buildMembershipsFromJira } from "@/lib/auth/access-state";
 
 export async function GET(request: Request, { params }: { params: { locale: string } }) {
   const supabase = createClient();
@@ -17,8 +18,11 @@ export async function GET(request: Request, { params }: { params: { locale: stri
 
   const user = session.user;
 
-  // 2. Default role
-  let role = "non_client";
+  let profileMemberships = {
+    role: "non_client",
+    is_partner: false,
+    is_customer: false,
+  };
 
   // 3. Call Jira webhook to check if the user exists
   try {
@@ -32,9 +36,7 @@ export async function GET(request: Request, { params }: { params: { locale: stri
 
       if (jiraResponse.ok) {
         const jiraData = await jiraResponse.json();
-        if (jiraData.isJiraUser) {
-          role = "partner";
-        }
+        profileMemberships = buildMembershipsFromJira(jiraData);
       } else {
         console.error("Jira webhook failed:", jiraResponse.statusText);
       }
@@ -47,11 +49,11 @@ export async function GET(request: Request, { params }: { params: { locale: stri
 
   // 4. Get current profile role
   try {
-    const { data: profile, error: profileError } = await supabase
-      .from("profiles")
-      .select("role")
-      .eq("id", user.id)
-      .single();
+      const { data: profile, error: profileError } = await supabase
+        .from("profiles")
+        .select("role")
+        .eq("id", user.id)
+        .single();
 
     if (profileError) {
       console.error("Error fetching profile:", profileError.message);
@@ -59,7 +61,7 @@ export async function GET(request: Request, { params }: { params: { locale: stri
       // 5. Update the user profile role only if not admin
       const { error: updateError } = await supabase
         .from("profiles")
-        .update({ role })
+        .update(profileMemberships)
         .eq("id", user.id);
 
       if (updateError) {

--- a/app/[locale]/auth/register/actions.ts
+++ b/app/[locale]/auth/register/actions.ts
@@ -1,5 +1,6 @@
 'use server';
 import { createClient } from '@/lib/supabase/server';
+import { buildMembershipsFromJira } from '@/lib/auth/access-state';
 import { z } from 'zod';
 
 export async function signUpWithJiraCheck(values: unknown) {
@@ -16,8 +17,11 @@ export async function signUpWithJiraCheck(values: unknown) {
   const { email, password } = parsed.data;
   const supabase = createClient();
 
-  // Variable to store the user role
-  let userRole = 'non_client'; // Default role for non-Jira users
+  let profileMemberships = {
+    role: 'non_client',
+    is_partner: false,
+    is_customer: false,
+  };
 
   // 1. Jira Webhook Check
   try {
@@ -39,10 +43,7 @@ export async function signUpWithJiraCheck(values: unknown) {
     }
 
     const jiraData = await jiraResponse.json();
-    
-    if (jiraData.isJiraUser) {
-      userRole = 'partner';
-    }
+    profileMemberships = buildMembershipsFromJira(jiraData);
   } catch (e) {
     console.error('Error calling Jira webhook:', e);
     // seguimos con non_client si falla
@@ -68,7 +69,7 @@ export async function signUpWithJiraCheck(values: unknown) {
       .from('profiles')
       .upsert({
         id: signUpData.user.id, // el mismo id que el user
-        role: userRole,
+        ...profileMemberships,
       });
 
     if (profileError) {

--- a/components/chat-agent.tsx
+++ b/components/chat-agent.tsx
@@ -22,7 +22,7 @@ export interface Agent {
   path: string
   color: string
   icon: string
-  access_level: 'public' | 'non_client' | 'partner' | 'admin'
+  access_level: 'public' | 'non_client' | 'partner' | 'customer' | 'admin'
   requires_email?: boolean
   chatwoot_inbox_identifier?: string | null
 }

--- a/components/chat-interface.tsx
+++ b/components/chat-interface.tsx
@@ -38,7 +38,7 @@ export interface Agent {
   path: string
   color: string
   icon: string
-  access_level: "public" | "non_client" | "partner" | "admin"
+  access_level: "public" | "non_client" | "partner" | "customer" | "admin"
   requires_email?: boolean
   chatwoot_inbox_identifier?: string | null
 }

--- a/lib/agents/access.ts
+++ b/lib/agents/access.ts
@@ -1,13 +1,12 @@
-export type AgentAccessLevel = 'public' | 'non_client' | 'partner' | 'admin'
-export type UserRole = 'non_client' | 'partner' | 'admin' | null
+import type { AgentAccessLevel, ProfileAccessState } from '@/lib/auth/access-state'
 
 export interface AccessContext {
   accessLevel: AgentAccessLevel
-  userRole: UserRole
+  accessState: ProfileAccessState | null
   isAuthenticated: boolean
 }
 
-export function canUserAccessAgent({ accessLevel, userRole, isAuthenticated }: AccessContext): boolean {
+export function canUserAccessAgent({ accessLevel, accessState, isAuthenticated }: AccessContext): boolean {
   if (accessLevel === 'public') {
     return !isAuthenticated
   }
@@ -16,36 +15,52 @@ export function canUserAccessAgent({ accessLevel, userRole, isAuthenticated }: A
     return false
   }
 
+  if (accessState?.isAdmin) {
+    return true
+  }
+
   if (accessLevel === 'non_client') {
-    return userRole === 'non_client' || userRole === 'admin'
+    return Boolean(accessState) && accessState?.isPartner !== true && accessState?.isCustomer !== true
   }
 
   if (accessLevel === 'partner') {
-    return userRole === 'partner' || userRole === 'admin'
+    return Boolean(accessState?.isPartner)
+  }
+
+  if (accessLevel === 'customer') {
+    return Boolean(accessState?.isCustomer)
   }
 
   if (accessLevel === 'admin') {
-    return userRole === 'admin'
+    return accessState?.isAdmin === true
   }
 
   return false
 }
 
-export function shouldListAgentOnHome(accessLevel: AgentAccessLevel, userRole: UserRole): boolean {
+export function shouldListAgentOnHome(accessLevel: AgentAccessLevel, accessState: ProfileAccessState | null): boolean {
   if (accessLevel === 'public') {
     return false
   }
 
+  if (accessState?.isAdmin) {
+    return true
+  }
+
   if (accessLevel === 'non_client') {
-    return userRole === 'non_client' || userRole === 'admin'
+    return Boolean(accessState) && accessState?.isPartner !== true && accessState?.isCustomer !== true
   }
 
   if (accessLevel === 'partner') {
-    return userRole === 'partner' || userRole === 'admin'
+    return accessState?.isPartner === true
+  }
+
+  if (accessLevel === 'customer') {
+    return accessState?.isCustomer === true
   }
 
   if (accessLevel === 'admin') {
-    return userRole === 'admin'
+    return accessState?.isAdmin === true
   }
 
   return false

--- a/lib/auth/access-state.ts
+++ b/lib/auth/access-state.ts
@@ -1,0 +1,71 @@
+export type AgentAccessLevel = 'public' | 'non_client' | 'partner' | 'customer' | 'admin'
+
+export interface JiraMembershipResponse {
+  isJiraUser?: boolean
+  isESD?: boolean
+  isCSP?: boolean
+}
+
+export interface ProfileAccessState {
+  role: string | null
+  isPartner: boolean
+  isCustomer: boolean
+  isAdmin: boolean
+}
+
+export interface PersistedProfileMemberships {
+  role: string
+  is_partner: boolean
+  is_customer: boolean
+}
+
+export function buildProfileAccessState(profile: {
+  role?: string | null
+  is_partner?: boolean | null
+  is_customer?: boolean | null
+} | null | undefined): ProfileAccessState {
+  const role = profile?.role ?? null
+  const isAdmin = role === 'admin'
+
+  return {
+    role,
+    isPartner: Boolean(profile?.is_partner),
+    isCustomer: Boolean(profile?.is_customer),
+    isAdmin,
+  }
+}
+
+export function buildMembershipsFromJira(jiraData: JiraMembershipResponse): PersistedProfileMemberships {
+  const isPartner = Boolean(jiraData.isESD)
+  const isCustomer = Boolean(jiraData.isCSP)
+
+  return {
+    role: isPartner ? 'partner' : 'non_client',
+    is_partner: isPartner,
+    is_customer: isCustomer,
+  }
+}
+
+export function getUserAccessLabel(accessState: ProfileAccessState | null): string | null {
+  if (!accessState) {
+    return null
+  }
+
+  if (accessState.isAdmin) {
+    return 'admin'
+  }
+
+  if (accessState.isPartner && accessState.isCustomer) {
+    return 'partner_customer'
+  }
+
+  if (accessState.isPartner) {
+    return 'partner'
+  }
+
+  if (accessState.isCustomer) {
+    return 'customer'
+  }
+
+  return 'non_client'
+}

--- a/messages/en/admin.json
+++ b/messages/en/admin.json
@@ -52,6 +52,7 @@
         "public": "Public",
         "non_client": "Non Client",
         "partner": "Partner",
+        "customer": "Customer",
         "admin": "Admin"
       }
     },

--- a/messages/es/admin.json
+++ b/messages/es/admin.json
@@ -52,6 +52,7 @@
         "public": "Público",
         "non_client": "No cliente",
         "partner": "Socio",
+        "customer": "Cliente",
         "admin": "Administrador"
       }
     },

--- a/tests/access.test.ts
+++ b/tests/access.test.ts
@@ -1,63 +1,80 @@
 import { canUserAccessAgent, shouldListAgentOnHome } from '../lib/agents/access'
 
+const nonClientState = { role: 'non_client', isPartner: false, isCustomer: false, isAdmin: false } as const
+const partnerState = { role: 'partner', isPartner: true, isCustomer: false, isAdmin: false } as const
+const customerState = { role: 'non_client', isPartner: false, isCustomer: true, isAdmin: false } as const
+const mixedState = { role: 'partner', isPartner: true, isCustomer: true, isAdmin: false } as const
+const adminState = { role: 'admin', isPartner: false, isCustomer: false, isAdmin: true } as const
+
 describe('Agent access helpers', () => {
   describe('canUserAccessAgent', () => {
     it('allows guests on public agents only', () => {
-      expect(canUserAccessAgent({ accessLevel: 'public', isAuthenticated: false, userRole: null })).toBe(true)
-      expect(canUserAccessAgent({ accessLevel: 'partner', isAuthenticated: false, userRole: null })).toBe(false)
+      expect(canUserAccessAgent({ accessLevel: 'public', isAuthenticated: false, accessState: null })).toBe(true)
+      expect(canUserAccessAgent({ accessLevel: 'partner', isAuthenticated: false, accessState: null })).toBe(false)
     })
 
     it('grants partner agent access only to partner or admin users', () => {
-      expect(canUserAccessAgent({ accessLevel: 'partner', isAuthenticated: true, userRole: 'partner' })).toBe(true)
-      expect(canUserAccessAgent({ accessLevel: 'partner', isAuthenticated: true, userRole: 'admin' })).toBe(true)
-      expect(canUserAccessAgent({ accessLevel: 'partner', isAuthenticated: true, userRole: 'non_client' })).toBe(false)
+      expect(canUserAccessAgent({ accessLevel: 'partner', isAuthenticated: true, accessState: partnerState })).toBe(true)
+      expect(canUserAccessAgent({ accessLevel: 'partner', isAuthenticated: true, accessState: adminState })).toBe(true)
+      expect(canUserAccessAgent({ accessLevel: 'partner', isAuthenticated: true, accessState: nonClientState })).toBe(false)
     })
 
-    it('grants non_client agent access to matching role or admin', () => {
-      expect(canUserAccessAgent({ accessLevel: 'non_client', isAuthenticated: true, userRole: 'non_client' })).toBe(true)
-      expect(canUserAccessAgent({ accessLevel: 'non_client', isAuthenticated: true, userRole: 'partner' })).toBe(false)
-      expect(canUserAccessAgent({ accessLevel: 'non_client', isAuthenticated: true, userRole: 'admin' })).toBe(true)
+    it('grants customer agent access to customer or mixed memberships', () => {
+      expect(canUserAccessAgent({ accessLevel: 'customer', isAuthenticated: true, accessState: customerState })).toBe(true)
+      expect(canUserAccessAgent({ accessLevel: 'customer', isAuthenticated: true, accessState: mixedState })).toBe(true)
+      expect(canUserAccessAgent({ accessLevel: 'customer', isAuthenticated: true, accessState: nonClientState })).toBe(false)
+    })
+
+    it('grants non_client agent access only to users without Jira memberships or admin', () => {
+      expect(canUserAccessAgent({ accessLevel: 'non_client', isAuthenticated: true, accessState: nonClientState })).toBe(true)
+      expect(canUserAccessAgent({ accessLevel: 'non_client', isAuthenticated: true, accessState: partnerState })).toBe(false)
+      expect(canUserAccessAgent({ accessLevel: 'non_client', isAuthenticated: true, accessState: customerState })).toBe(false)
+      expect(canUserAccessAgent({ accessLevel: 'non_client', isAuthenticated: true, accessState: adminState })).toBe(true)
     })
 
     it('restricts admin agents to admins only', () => {
-      expect(canUserAccessAgent({ accessLevel: 'admin', isAuthenticated: true, userRole: 'admin' })).toBe(true)
-      expect(canUserAccessAgent({ accessLevel: 'admin', isAuthenticated: true, userRole: 'partner' })).toBe(false)
+      expect(canUserAccessAgent({ accessLevel: 'admin', isAuthenticated: true, accessState: adminState })).toBe(true)
+      expect(canUserAccessAgent({ accessLevel: 'admin', isAuthenticated: true, accessState: partnerState })).toBe(false)
     })
 
     it('denies access when authenticated user has no role metadata', () => {
-      expect(canUserAccessAgent({ accessLevel: 'non_client', isAuthenticated: true, userRole: null })).toBe(false)
-      expect(canUserAccessAgent({ accessLevel: 'partner', isAuthenticated: true, userRole: null })).toBe(false)
+      expect(canUserAccessAgent({ accessLevel: 'non_client', isAuthenticated: true, accessState: null })).toBe(false)
+      expect(canUserAccessAgent({ accessLevel: 'partner', isAuthenticated: true, accessState: null })).toBe(false)
     })
 
     it('always denies non-public agents to unauthenticated users', () => {
-      ;(['non_client', 'partner', 'admin'] as const).forEach(level => {
-        expect(canUserAccessAgent({ accessLevel: level, isAuthenticated: false, userRole: null })).toBe(false)
+      ;(['non_client', 'partner', 'customer', 'admin'] as const).forEach(level => {
+        expect(canUserAccessAgent({ accessLevel: level, isAuthenticated: false, accessState: null })).toBe(false)
       })
     })
   })
 
   describe('shouldListAgentOnHome', () => {
     it('never lists public agents on authenticated dashboard', () => {
-      expect(shouldListAgentOnHome('public', 'admin')).toBe(false)
-      expect(shouldListAgentOnHome('public', 'non_client')).toBe(false)
+      expect(shouldListAgentOnHome('public', adminState)).toBe(false)
+      expect(shouldListAgentOnHome('public', nonClientState)).toBe(false)
     })
 
     it('respects role alignment', () => {
-      expect(shouldListAgentOnHome('partner', 'partner')).toBe(true)
-      expect(shouldListAgentOnHome('partner', 'non_client')).toBe(false)
-      expect(shouldListAgentOnHome('non_client', 'non_client')).toBe(true)
-      expect(shouldListAgentOnHome('non_client', 'partner')).toBe(false)
+      expect(shouldListAgentOnHome('partner', partnerState)).toBe(true)
+      expect(shouldListAgentOnHome('partner', nonClientState)).toBe(false)
+      expect(shouldListAgentOnHome('customer', customerState)).toBe(true)
+      expect(shouldListAgentOnHome('customer', partnerState)).toBe(false)
+      expect(shouldListAgentOnHome('non_client', nonClientState)).toBe(true)
+      expect(shouldListAgentOnHome('non_client', mixedState)).toBe(false)
     })
 
     it('allows admins to see everything but public agents', () => {
-      expect(shouldListAgentOnHome('partner', 'admin')).toBe(true)
-      expect(shouldListAgentOnHome('non_client', 'admin')).toBe(true)
-      expect(shouldListAgentOnHome('admin', 'admin')).toBe(true)
+      expect(shouldListAgentOnHome('partner', adminState)).toBe(true)
+      expect(shouldListAgentOnHome('customer', adminState)).toBe(true)
+      expect(shouldListAgentOnHome('non_client', adminState)).toBe(true)
+      expect(shouldListAgentOnHome('admin', adminState)).toBe(true)
     })
 
     it('hides non-public agents when user role is unknown', () => {
       expect(shouldListAgentOnHome('non_client', null)).toBe(false)
       expect(shouldListAgentOnHome('partner', null)).toBe(false)
+      expect(shouldListAgentOnHome('customer', null)).toBe(false)
       expect(shouldListAgentOnHome('admin', null)).toBe(false)
     })
   })

--- a/tests/auth-callback.test.ts
+++ b/tests/auth-callback.test.ts
@@ -21,7 +21,7 @@ describe('auth callback route', () => {
 
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve({ isJiraUser: true }),
+      json: () => Promise.resolve({ isJiraUser: true, isESD: true, isCSP: false }),
     })
 
     selectMock.mockReturnValue({ eq: selectEqMock })
@@ -54,9 +54,31 @@ describe('auth callback route', () => {
     const response = await GET(request, { params: { locale: 'en' } })
 
     expect(exchangeCodeMock).toHaveBeenCalledWith('abc')
-    expect(updateMock).toHaveBeenCalledWith({ role: 'partner' })
+    expect(updateMock).toHaveBeenCalledWith({
+      role: 'partner',
+      is_partner: true,
+      is_customer: false,
+    })
     expect(updateEqMock).toHaveBeenCalledWith('id', 'user-1')
     expect(response.headers.get('location')).toBe('https://app.com/en')
+  })
+
+  it('stores customer membership without changing admin redirect logic', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ isJiraUser: true, isESD: false, isCSP: true }),
+    })
+
+    const { GET } = await import('../app/[locale]/auth/callback/route')
+    const request = new Request('https://app.com/en/auth/callback?code=abc')
+
+    await GET(request, { params: { locale: 'en' } })
+
+    expect(updateMock).toHaveBeenCalledWith({
+      role: 'non_client',
+      is_partner: false,
+      is_customer: true,
+    })
   })
 
   it('skips role update for admin profiles', async () => {

--- a/tests/route-guards.test.tsx
+++ b/tests/route-guards.test.tsx
@@ -20,6 +20,8 @@ const chatProfileSingleMock = vi.hoisted(() => vi.fn())
 vi.mock('next/navigation', () => ({
   redirect: redirectMock,
   notFound: vi.fn(),
+  useRouter: () => ({ replace: vi.fn(), push: vi.fn() }),
+  usePathname: () => '/en/chat/special',
 }))
 
 vi.mock('next/headers', () => ({
@@ -79,7 +81,13 @@ vi.mock('@/lib/supabase/server', () => ({
 
       return {
         select: () => ({
-          eq: () => ({ maybeSingle: vi.fn().mockResolvedValue({ data: null }) }),
+          eq: () => ({
+            eq: () => ({
+              maybeSingle: vi.fn().mockResolvedValue({ data: null }),
+              order: vi.fn().mockResolvedValue({ data: [] }),
+            }),
+            order: vi.fn().mockResolvedValue({ data: [] }),
+          }),
           order: vi.fn().mockResolvedValue({ data: [] }),
         }),
       }
@@ -127,7 +135,7 @@ describe('route guards', () => {
   it('shows access denied for authenticated user without required role', async () => {
     const t = createTranslator('en', 'chat.errors.accessDenied')
     chatAuthUserMock.mockResolvedValue({ data: { user: { id: 'u1', email: 'demo@example.com' } } })
-    chatProfileSingleMock.mockResolvedValue({ data: { role: 'partner' }, error: null })
+    chatProfileSingleMock.mockResolvedValue({ data: { role: 'partner', is_partner: true, is_customer: false }, error: null })
     chatAgentSingleMock.mockResolvedValue({
       data: { id: 'agent-1', access_level: 'non_client', path: '/special' },
       error: null,

--- a/tests/signUpWithJiraCheck.test.ts
+++ b/tests/signUpWithJiraCheck.test.ts
@@ -42,10 +42,10 @@ describe('signUpWithJiraCheck', () => {
     process.env.JIRA_WEBHOOK_URL = originalEnv
   })
 
-  it('assigns partner role when Jira webhook confirms membership', async () => {
-    ;(global.fetch as vi.Mock).mockResolvedValue({
+  it('assigns partner membership when Jira webhook confirms ESD membership', async () => {
+    ;(global.fetch as any).mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve({ isJiraUser: true }),
+      json: () => Promise.resolve({ isJiraUser: true, isESD: true, isCSP: false }),
     })
 
     const { signUpWithJiraCheck } = await import('../app/[locale]/auth/register/actions')
@@ -53,26 +53,54 @@ describe('signUpWithJiraCheck', () => {
 
     expect(result).toEqual({ success: true })
     expect(signUpMock).toHaveBeenCalledWith({ email: 'user@example.com', password: 'secret123' })
-    expect(upsertMock).toHaveBeenCalledWith({ id: 'user-1', role: 'partner' })
+    expect(upsertMock).toHaveBeenCalledWith({
+      id: 'user-1',
+      role: 'partner',
+      is_partner: true,
+      is_customer: false,
+    })
   })
 
-  it('defaults to non_client when Jira webhook returns false', async () => {
-    ;(global.fetch as vi.Mock).mockResolvedValue({
+  it('stores customer membership without breaking legacy non_client role', async () => {
+    ;(global.fetch as any).mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve({ isJiraUser: false }),
+      json: () => Promise.resolve({ isJiraUser: true, isESD: false, isCSP: true }),
     })
 
     const { signUpWithJiraCheck } = await import('../app/[locale]/auth/register/actions')
     const result = await signUpWithJiraCheck({ email: 'user@example.com', password: 'secret123' })
 
     expect(result).toEqual({ success: true })
-    expect(upsertMock).toHaveBeenCalledWith({ id: 'user-1', role: 'non_client' })
+    expect(upsertMock).toHaveBeenCalledWith({
+      id: 'user-1',
+      role: 'non_client',
+      is_partner: false,
+      is_customer: true,
+    })
+  })
+
+  it('stores both memberships when user belongs to both Jira desks', async () => {
+    ;(global.fetch as any).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ isJiraUser: true, isESD: true, isCSP: true }),
+    })
+
+    const { signUpWithJiraCheck } = await import('../app/[locale]/auth/register/actions')
+    const result = await signUpWithJiraCheck({ email: 'user@example.com', password: 'secret123' })
+
+    expect(result).toEqual({ success: true })
+    expect(upsertMock).toHaveBeenCalledWith({
+      id: 'user-1',
+      role: 'partner',
+      is_partner: true,
+      is_customer: true,
+    })
   })
 
   it('returns error when sign up fails', async () => {
-    ;(global.fetch as vi.Mock).mockResolvedValue({
+    ;(global.fetch as any).mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve({ isJiraUser: false }),
+      json: () => Promise.resolve({ isJiraUser: false, isESD: false, isCSP: false }),
     })
 
     signUpMock.mockResolvedValue({ data: { user: null }, error: { message: 'duplicate' } })


### PR DESCRIPTION
- Added "customer" access level to the system, allowing for more granular user permissions.
- Updated user role fetching logic to include new access states (is_partner, is_customer) from the profiles table.
- Refactored access control functions to utilize the new ProfileAccessState interface, improving clarity and maintainability.
- Modified various components and pages to accommodate the new access level and updated role checks.
- Enhanced tests to cover new access scenarios and ensure proper functionality with the updated role structure.
- Updated localization files to include translations for the new "customer" role.